### PR TITLE
Manifest and icons in amp with schema code on top

### DIFF
--- a/includes/options/options-init.php
+++ b/includes/options/options-init.php
@@ -205,14 +205,14 @@
         // App icons and Manifest
 
          array(
-                'id'       => 'app-favicon',
+                'id'       => 'amp-app-favicon',
                 'type'     => 'media', 
                 'url'      => true,
                 'title'    => __('Favicon', 'redux-framework-demo'),
                 'desc' => __('Upload a favicon for the AMP version. Recommend logo size is: 48x48', 'redux-framework-demo'),
             ),
             array(
-                'id'       => 'app-icon',
+                'id'       => 'amp-app-icon',
                 'type'     => 'media', 
                 'url'      => true,
                 'title'    => __('Icon', 'redux-framework-demo'),
@@ -225,7 +225,7 @@
             'default'  => '/manifest.json'
         ),  
          array(
-            'id'       => 'app-name',
+            'id'       => 'amp-app-name',
             'title'    => __('The name of your application', 'redux-framework-demo'),
             'type'     => 'text',  
             'default'  => 'A Blog'

--- a/includes/options/options-init.php
+++ b/includes/options/options-init.php
@@ -201,7 +201,35 @@
             //    'subtitle' => __('Look, it\'s on!', 'redux-framework-demo'),
             //    'default'  => true
             //),
-           
+            
+        // App icons and Manifest
+
+         array(
+                'id'       => 'app-favicon',
+                'type'     => 'media', 
+                'url'      => true,
+                'title'    => __('Favicon', 'redux-framework-demo'),
+                'desc' => __('Upload a favicon for the AMP version. Recommend logo size is: 48x48', 'redux-framework-demo'),
+            ),
+            array(
+                'id'       => 'app-icon',
+                'type'     => 'media', 
+                'url'      => true,
+                'title'    => __('Icon', 'redux-framework-demo'),
+                'desc' => __('Upload a favicon for the AMP version. Recommend logo size is: 512x512', 'redux-framework-demo'),
+            ),
+            array(
+            'id'       => 'amp-manifest-file',
+            'title'    => __('URL to your manifest file', 'redux-framework-demo'),
+            'type'     => 'text',  
+            'default'  => '/manifest.json'
+        ),  
+         array(
+            'id'       => 'app-name',
+            'title'    => __('The name of your application', 'redux-framework-demo'),
+            'type'     => 'text',  
+            'default'  => 'A Blog'
+
         array(
             'id'       => 'ga-feild',
             'type'     => 'text', 

--- a/includes/options/options-init.php
+++ b/includes/options/options-init.php
@@ -360,7 +360,7 @@ array(
             'required' => array('amp-custom-icons', '=' , '1'),
             'default'  => 'Enter your app name here.'
         ),
-      
+      ),
     ) );
     
      // Notifications SECTION

--- a/includes/options/options-init.php
+++ b/includes/options/options-init.php
@@ -333,7 +333,7 @@ array(
          array(
                 'id'       => 'amp-app-favicon',
                 'type'     => 'media', 
-                'required' => array('amp-custom-icons', '=' , '1'),
+                'required' => array('enable-amp-custom-icons', '=' , '1'),
                 'url'      => true,
                 'title'    => __('Favicon', 'redux-framework-demo'),
                 'desc' => __('Upload a favicon for the AMP version. Recommend logo size is: 48x48', 'redux-framework-demo'),
@@ -341,7 +341,7 @@ array(
             array(
                 'id'       => 'amp-app-icon',
                 'type'     => 'media', 
-                'required' => array('amp-custom-icons', '=' , '1'),
+                'required' => array('enable-amp-custom-icons', '=' , '1'),
                 'url'      => true,
                 'title'    => __('Icon', 'redux-framework-demo'),
                 'desc' => __('Upload a favicon for the AMP version. Recommend logo size is: 512x512', 'redux-framework-demo'),
@@ -350,14 +350,14 @@ array(
             'id'       => 'amp-manifest-file',
             'title'    => __('URL to your manifest file', 'redux-framework-demo'),
             'type'     => 'text',  
-            'required' => array('amp-custom-icons', '=' , '1'),
+            'required' => array('enable-amp-custom-icons', '=' , '1'),
             'default'  => '/manifest.json'
         ),  
          array(
             'id'       => 'amp-app-name',
             'title'    => __('The name of your application', 'redux-framework-demo'),
             'type'     => 'text',  
-            'required' => array('amp-custom-icons', '=' , '1'),
+            'required' => array('enable-amp-custom-icons', '=' , '1'),
             'default'  => 'Enter your app name here.'
         ),
       ),

--- a/includes/options/options-init.php
+++ b/includes/options/options-init.php
@@ -202,34 +202,6 @@
             //    'default'  => true
             //),
             
-        // App icons and Manifest
-
-         array(
-                'id'       => 'amp-app-favicon',
-                'type'     => 'media', 
-                'url'      => true,
-                'title'    => __('Favicon', 'redux-framework-demo'),
-                'desc' => __('Upload a favicon for the AMP version. Recommend logo size is: 48x48', 'redux-framework-demo'),
-            ),
-            array(
-                'id'       => 'amp-app-icon',
-                'type'     => 'media', 
-                'url'      => true,
-                'title'    => __('Icon', 'redux-framework-demo'),
-                'desc' => __('Upload a favicon for the AMP version. Recommend logo size is: 512x512', 'redux-framework-demo'),
-            ),
-            array(
-            'id'       => 'amp-manifest-file',
-            'title'    => __('URL to your manifest file', 'redux-framework-demo'),
-            'type'     => 'text',  
-            'default'  => '/manifest.json'
-        ),  
-         array(
-            'id'       => 'amp-app-name',
-            'title'    => __('The name of your application', 'redux-framework-demo'),
-            'type'     => 'text',  
-            'default'  => 'A Blog'
-
         array(
             'id'       => 'ga-feild',
             'type'     => 'text', 
@@ -340,6 +312,55 @@ array(
 
      
         
+    ) );
+
+     // ICONS SECTION
+    Redux::setSection( $opt_name, array(
+        'title'      => __( 'Icons', 'redux-framework-demo' ),
+        'desc'       => __( 'Add custom icons to your AMP pages'),
+        'id'         => 'amp-custom-icons',
+        'subsection' => true,
+        'fields'     => array(
+            array(
+                'id'        =>'enable-amp-custom-icons',
+                'type'      => 'switch', 
+                'title'     => __('Enable custom icons', 'redux-framework-demo'),
+                'default'   => 0,
+                'subtitle'  => __('Enable custom icons for structured data and for favicon/manifest', 'redux-framework-demo'),
+                'true'      => 'Enabled',
+                'false'     => 'Disabled',
+            ),
+         array(
+                'id'       => 'amp-app-favicon',
+                'type'     => 'media', 
+                'required' => array('amp-custom-icons', '=' , '1'),
+                'url'      => true,
+                'title'    => __('Favicon', 'redux-framework-demo'),
+                'desc' => __('Upload a favicon for the AMP version. Recommend logo size is: 48x48', 'redux-framework-demo'),
+            ),
+            array(
+                'id'       => 'amp-app-icon',
+                'type'     => 'media', 
+                'required' => array('amp-custom-icons', '=' , '1'),
+                'url'      => true,
+                'title'    => __('Icon', 'redux-framework-demo'),
+                'desc' => __('Upload a favicon for the AMP version. Recommend logo size is: 512x512', 'redux-framework-demo'),
+            ),
+            array(
+            'id'       => 'amp-manifest-file',
+            'title'    => __('URL to your manifest file', 'redux-framework-demo'),
+            'type'     => 'text',  
+            'required' => array('amp-custom-icons', '=' , '1'),
+            'default'  => '/manifest.json'
+        ),  
+         array(
+            'id'       => 'amp-app-name',
+            'title'    => __('The name of your application', 'redux-framework-demo'),
+            'type'     => 'text',  
+            'required' => array('amp-custom-icons', '=' , '1'),
+            'default'  => 'Enter your app name here.'
+        ),
+      
     ) );
     
      // Notifications SECTION

--- a/templates/features.php
+++ b/templates/features.php
@@ -376,9 +376,15 @@
 				global $redux_builder_amp;
 				$metadata['publisher']['logo'] = array(
 					'@type' => 'ImageObject',
-					'url' =>   $redux_builder_amp['opt-media']['url'],
-					'height' => 36,
-					'width' => 190,
+					'url' =>   $redux_builder_amp['amp-app-favicon']['url'],
+					'height' => 48,
+					'width' => 48,
+				);
+				$metadata[''] = array(
+					'@type' => 'ImageObject',
+					'url' =>   $thumb_url,
+					'height' => 512,
+					'width' => 300,
 				);
 				return $metadata;
 		}

--- a/templates/frontpage.php
+++ b/templates/frontpage.php
@@ -6,9 +6,9 @@
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
 
 	<link rel="manifest" href="<?php echo $redux_builder_amp['amp-manifest-file']; ?>">
-	<meta name="application-name" content="<?php echo $redux_builder_amp['app-name']; ?>">
-    <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['app-favicon']['url']; ?>">
-    <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['app-icon']['url']; ?>">
+	<meta name="application-name" content="<?php echo $redux_builder_amp['amp-app-name']; ?>">
+    <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['amp-app-favicon']['url']; ?>">
+    <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['amp-app-icon']['url']; ?>">
 
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 

--- a/templates/frontpage.php
+++ b/templates/frontpage.php
@@ -4,12 +4,12 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
-
+    <?php if($redux_builder_amp['enable-amp-custom-icons'] == true) { ?>
 	<link rel="manifest" href="<?php echo $redux_builder_amp['amp-manifest-file']; ?>">
 	<meta name="application-name" content="<?php echo $redux_builder_amp['amp-app-name']; ?>">
     <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['amp-app-favicon']['url']; ?>">
     <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['amp-app-icon']['url']; ?>">
-
+    <?php } ?>
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>

--- a/templates/frontpage.php
+++ b/templates/frontpage.php
@@ -4,6 +4,12 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
+
+	<link rel="manifest" href="<?php echo $redux_builder_amp['amp-manifest-file']; ?>">
+	<meta name="application-name" content="<?php echo $redux_builder_amp['app-name']; ?>">
+    <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['app-favicon']['url']; ?>">
+    <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['app-icon']['url']; ?>">
+
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>

--- a/templates/index.php
+++ b/templates/index.php
@@ -6,9 +6,9 @@
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
 
 	<link rel="manifest" href="<?php echo $redux_builder_amp['amp-manifest-file']; ?>">
-	<meta name="application-name" content="<?php echo $redux_builder_amp['app-name']; ?>">
-    <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['app-favicon']['url']; ?>">
-    <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['app-icon']['url']; ?>">
+	<meta name="application-name" content="<?php echo $redux_builder_amp['amp-app-name']; ?>">
+    <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['amp-app-favicon']['url']; ?>">
+    <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['amp-app-icon']['url']; ?>">
 
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 

--- a/templates/index.php
+++ b/templates/index.php
@@ -4,12 +4,12 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
-
+    <?php if($redux_builder_amp['enable-amp-custom-icons'] == true) { ?>
 	<link rel="manifest" href="<?php echo $redux_builder_amp['amp-manifest-file']; ?>">
 	<meta name="application-name" content="<?php echo $redux_builder_amp['amp-app-name']; ?>">
     <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['amp-app-favicon']['url']; ?>">
     <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['amp-app-icon']['url']; ?>">
-
+    <?php } ?>
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>

--- a/templates/index.php
+++ b/templates/index.php
@@ -4,6 +4,12 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
+
+	<link rel="manifest" href="<?php echo $redux_builder_amp['amp-manifest-file']; ?>">
+	<meta name="application-name" content="<?php echo $redux_builder_amp['app-name']; ?>">
+    <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['app-favicon']['url']; ?>">
+    <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['app-icon']['url']; ?>">
+
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>

--- a/templates/single.php
+++ b/templates/single.php
@@ -6,9 +6,9 @@
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
 
 	<link rel="manifest" href="<?php echo $redux_builder_amp['amp-manifest-file']; ?>">
-	<meta name="application-name" content="<?php echo $redux_builder_amp['app-name']; ?>">
-    <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['app-favicon']['url']; ?>">
-    <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['app-icon']['url']; ?>">
+	<meta name="application-name" content="<?php echo $redux_builder_amp['amp-app-name']; ?>">
+    <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['amp-app-favicon']['url']; ?>">
+    <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['amp-app-icon']['url']; ?>">
 
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 

--- a/templates/single.php
+++ b/templates/single.php
@@ -4,12 +4,12 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
-
+    <?php if($redux_builder_amp['enable-amp-custom-icons'] == true) { ?>
 	<link rel="manifest" href="<?php echo $redux_builder_amp['amp-manifest-file']; ?>">
 	<meta name="application-name" content="<?php echo $redux_builder_amp['amp-app-name']; ?>">
     <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['amp-app-favicon']['url']; ?>">
     <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['amp-app-icon']['url']; ?>">
-
+    <?php } ?>
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>

--- a/templates/single.php
+++ b/templates/single.php
@@ -4,6 +4,12 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width,initial-scale=1,minimum-scale=1,maximum-scale=1,user-scalable=no">
+
+	<link rel="manifest" href="<?php echo $redux_builder_amp['amp-manifest-file']; ?>">
+	<meta name="application-name" content="<?php echo $redux_builder_amp['app-name']; ?>">
+    <link rel="icon" sizes="16x16 32x32 48x48" href="<?php echo $redux_builder_amp['app-favicon']['url']; ?>">
+    <link rel="icon" sizes="512x512" href="<?php echo $redux_builder_amp['app-icon']['url']; ?>">
+
 	<?php do_action( 'amp_post_template_head', $this ); ?>
 
 	<style amp-custom>


### PR DESCRIPTION
This pull is taking over from what I did with #141 and implements it in a new way.

// Orignal Pull

This code takes everything I did with the pull #119 and adds schema to it, so that favicons can be used as the organisation logo.

It also adds the schema data for the featured image.

Currently, I have only tested this with my own site, so I will be keeping my previous pull open.

In my own testing, it shows three schema's.

The article one does continue to show an error, however, the logo is loaded in the organisation schema. I am unsure if this wold be a problem, but my guess is that Google would take the information anyway. It would need more testing.
