### PR TITLE
Removed / before amp

### DIFF
--- a/templates/design-manager/design-3/index.php
+++ b/templates/design-manager/design-3/index.php
@@ -79,7 +79,7 @@ if ( get_query_var( 'paged' ) ) {
 						?>
 						 <amp-img src=<?php echo $thumb_url ?> width=450 height=270></amp-img>
 					<?php } ?>
-                  <a href="<?php the_permalink(); ?>/amp">
+                  <a href="<?php the_permalink(); ?>amp">
                   <div class="featured_title">
 		            <div class="featured_time"><?php global $redux_builder_amp; echo human_time_diff( get_the_time('U'), current_time('timestamp') ) .' '. $redux_builder_amp['amp-translator-ago-date-text']; ?></div>
 		            <h1><?php the_title() ?></h1>


### PR DESCRIPTION
I remarked that the slider's URL ends up with //amp. So it's redirecting to non-AMP page. https://github.com/ahmedkaludi/accelerated-mobile-pages/issues/758