### PR TITLE
added a "/" to AMPFORWP_AMP_QUERY_VAR

### DIFF
--- a/accelerated-moblie-pages.php
+++ b/accelerated-moblie-pages.php
@@ -18,7 +18,7 @@ define('AMPFORWP_DISQUS_URL',plugin_dir_url(__FILE__).'includes/disqus.php');
 define('AMPFORWP_IMAGE_DIR',plugin_dir_url(__FILE__).'images');
 define('AMPFORWP_VERSION','0.9.47');
 // any changes to AMP_QUERY_VAR should be refelected here
-define('AMPFORWP_AMP_QUERY_VAR', apply_filters( 'amp_query_var', 'amp' ) );
+define('AMPFORWP_AMP_QUERY_VAR', apply_filters( 'amp_query_var', 'amp/' ) );
 
 
 // Rewrite the Endpoints after the plugin is activate, as priority is set to 11


### PR DESCRIPTION
This will fix 1 redirect.
insted of "example.com" 301-> "example.com/amp" 301-> "example.com/amp/"
it wil do "example.com" 301-> "example.com/amp/"