### PR TITLE
Typo fix for Linkedin Profile Page URL section

### DIFF
--- a/includes/options/admin-config.php
+++ b/includes/options/admin-config.php
@@ -1393,22 +1393,22 @@ Redux::setArgs( "redux_builder_amp", $args );
           ),
           //#5
           array(
-              'id'        =>  'enable-single-linkdin-profile',
+              'id'        =>  'enable-single-linkedin-profile',
               'type'      =>  'switch',
-              'title'     =>  __('Linkdin ', 'accelerated-mobile-pages'),
+              'title'     =>  __('Linkedin ', 'accelerated-mobile-pages'),
               'default'   =>  0,
               'required' => array(
                 array('amp-design-selector', '=' , '3')
               ),
           ),
           array(
-              'id'        =>  'enable-single-linkdin-profile-url',
+              'id'        =>  'enable-single-linkedin-profile-url',
               'type'      =>  'text',
-              'title'     =>  __('Linkdin URL', 'accelerated-mobile-pages'),
+              'title'     =>  __('Linkedin URL', 'accelerated-mobile-pages'),
               'default'   =>  '',
               'required' => array(
                 array('amp-design-selector', '=' , '3'),
-                array('enable-single-linkdin-profile', '=' , '1')
+                array('enable-single-linkedin-profile', '=' , '1')
               ),
           ),
           //#6

--- a/languages/ampforwp.pot
+++ b/languages/ampforwp.pot
@@ -1061,11 +1061,11 @@ msgid "Google Plus URL"
 msgstr ""
 
 #: includes/options/admin-config.php:1246
-msgid "Linkdin "
+msgid "Linkedin "
 msgstr ""
 
 #: includes/options/admin-config.php:1255
-msgid "Linkdin URL"
+msgid "Linkedin URL"
 msgstr ""
 
 #: includes/options/admin-config.php:1266

--- a/templates/design-manager/design-3/footer.php
+++ b/templates/design-manager/design-3/footer.php
@@ -70,8 +70,8 @@
               <?php } ?>
 
               <?php global $redux_builder_amp;
-              if( $redux_builder_amp['enable-single-linkdin-profile']  && $redux_builder_amp['enable-single-linkdin-profile-url'] !== '') { ?>
-              <a href="<?php echo $redux_builder_amp['enable-single-linkdin-profile-url']; ?>" target ="_blank"><li class="icon-linkedin"></li></a>
+              if( $redux_builder_amp['enable-single-linkedin-profile']  && $redux_builder_amp['enable-single-linkedin-profile-url'] !== '') { ?>
+              <a href="<?php echo $redux_builder_amp['enable-single-linkedin-profile-url']; ?>" target ="_blank"><li class="icon-linkedin"></li></a>
               <?php } ?>
 
               <?php global $redux_builder_amp;

--- a/templates/design-manager/design-3/header-bar.php
+++ b/templates/design-manager/design-3/header-bar.php
@@ -38,8 +38,8 @@
                             <?php } ?>
 
                             <?php global $redux_builder_amp;
-                            if( $redux_builder_amp['enable-single-linkdin-profile']  && $redux_builder_amp['enable-single-linkdin-profile-url'] !== '') { ?>
-                            <a href="<?php echo $redux_builder_amp['enable-single-linkdin-profile-url']; ?>" target ="_blank"><li class="icon-linkedin"></li></a>
+                            if( $redux_builder_amp['enable-single-linkedin-profile']  && $redux_builder_amp['enable-single-linkedin-profile-url'] !== '') { ?>
+                            <a href="<?php echo $redux_builder_amp['enable-single-linkedin-profile-url']; ?>" target ="_blank"><li class="icon-linkedin"></li></a>
                             <?php } ?>
 
                             <?php global $redux_builder_amp;

--- a/templates/features.php
+++ b/templates/features.php
@@ -2044,7 +2044,7 @@ if( !function_exists('ampforwp_checking_any_social_profiles') ) {
 			$redux_builder_amp['enable-single-facebook-profile'] 	 ||
 			$redux_builder_amp['enable-single-pintrest-profile'] 	 ||
 			$redux_builder_amp['enable-single-google-plus-profile']	 ||
-			$redux_builder_amp['enable-single-linkdin-profile'] 	 ||
+			$redux_builder_amp['enable-single-linkedin-profile'] 	 ||
 			$redux_builder_amp['enable-single-youtube-profile'] 	 ||
 			$redux_builder_amp['enable-single-instagram-profile'] 	 ||
 			$redux_builder_amp['enable-single-VKontakte-profile'] 	 ||


### PR DESCRIPTION
Changed all instances of `linkdin` with `linkedin `



![misspelling of linkedin as linkdin](https://i.imgur.com/6mHa8TF.png)