### PR TITLE
Fix amp-web-push helper iframe configuration URL

### DIFF
--- a/templates/features.php
+++ b/templates/features.php
@@ -4648,7 +4648,7 @@ if( ! function_exists( ' ampforwp_onesignal_notifications ' ) ){
 		// HTTPS sites
 		$onesignal_domain 		= trailingslashit( esc_url( home_url() ) ) ;
 		$onesignal_app_id		= $redux_builder_amp['ampforwp-one-signal-app-id'];
-		$helper_iframe_url = $onesignal_domain .'amphtml-helper-frame.html?appId=' . $onesignal_app_id;
+		$helper_iframe_url = $onesignal_domain .'amp-helper-frame.html?appId=' . $onesignal_app_id;
 
 		$permission_dialog_url = $onesignal_domain .'amp-permission-dialog.html?appId=' . $onesignal_app_id;
 


### PR DESCRIPTION
Change the <amp-web-push> configuration property "helper-frame-url"
value from "amphtml-helper-frame.html" to "amp-helper-frame.html".
"amp-helper-frame.html" is the file supplied by OneSignal's WordPress
plugin, and using "amphtml-helper-frame.html" causes a 404 Not Found
error.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ahmedkaludi/accelerated-mobile-pages/1387)
<!-- Reviewable:end -->
