### PR TITLE
fix(amp-playbuzz): remove src deprecated attribute code that cause error on debug mode

### DIFF
--- a/includes/vendor/amp/includes/sanitizers/class-amp-playbuzz-sanitizer.php
+++ b/includes/vendor/amp/includes/sanitizers/class-amp-playbuzz-sanitizer.php
@@ -51,13 +51,6 @@ class AMP_Playbuzz_Sanitizer extends AMP_Base_Sanitizer {
 			if ( ! isset( $new_attributes['data-item'] ) && ! isset( $new_attributes['src'] ) ) {
 				continue;
 			}
-
-			if ( $new_attributes['src'] ) {
-				$checker = preg_match("@^https?://@", $new_attributes['src'] ) ;
-				if ( empty( $checker ) ) {
-					$new_attributes['src'] = 'https:' . $new_attributes['src'];
-				}
-			}
 			
 			$new_node = AMP_DOM_Utils::create_node( $this->dom, self::$script_slug, $new_attributes );
 


### PR DESCRIPTION
amp-playbuzz throw an error on debug mode

There is a bug on checking if src attribute is set
This attribute is deprecated in Playbuzz and soon won't be supported at all

The fix:
1. Remove the code that manipulate src attribute, it not needed

#1674