### PR TITLE
Add support for Relevanssi search

### DIFF
--- a/components/loop/loop.php
+++ b/components/loop/loop.php
@@ -169,6 +169,12 @@ function call_loops_standard($data=array()){
 	
 	$filtered_args = apply_filters('ampforwp_query_args', $args);
 	$amp_q = new WP_Query( $filtered_args );
+
+	// If Relevanssi is available and this is a search, pass the query to Relevanssi
+	// for improved search results. 2018-07-03 Mikko Saari (mikko@mikkosaari.fi)
+	if ( is_search() && function_exists( 'relevanssi_do_query' ) ) {
+		relevanssi_do_query( $amp_q );
+	}
 }
 //call_loops_standered();
 /****


### PR DESCRIPTION
Accelerated Mobile Pages doesn't currently work with [Relevanssi](https://wordpress.org/plugins/relevanssi/) because the search template uses `new WP_Query()` to run the search query. Relevanssi can't override that automatically.

Adding support for improved search results from Relevanssi would be simple, however. Just check if it's a search and if Relevanssi is active, and if it is, just pass the search query through `relevanssi_do_query()`. That way users with AMP and Relevanssi would be able to get improved search results for AMP searches as well.