### PR TITLE
Bug fix for null reference exception

### DIFF
--- a/includes/vendor/amp/includes/sanitizers/class-amp-blacklist-sanitizer.php
+++ b/includes/vendor/amp/includes/sanitizers/class-amp-blacklist-sanitizer.php
@@ -89,6 +89,7 @@ class AMP_Blacklist_Sanitizer extends AMP_Base_Sanitizer {
 			for ( $i = $length - 1; $i >= 0; $i-- ) {
 				$element = $elements->item( $i );
 				// Allow script with application/ld+json #1958
+				if(is_null($element))continue; //Bug fix for null reference exception
 				if ( $element->hasAttributes() ) {
 					$attr = $element->getAttribute('type');
 					if ( '' !== $attr && 'application/ld+json' === $attr ) {


### PR DESCRIPTION
In certain scenario $element becomes  null causing $element->hasAttributes() to throw a null reference exception. Fixed it by introducing a null check.