### PR TITLE
Fix error undefined index fb-instant-page

### DIFF
--- a/templates/features.php
+++ b/templates/features.php
@@ -4456,10 +4456,9 @@ function fb_instant_article_feed_function() {
 if ( ! function_exists('ampforwp_fbia_meta_tags') ) {
 	function ampforwp_fbia_meta_tags(){
 		global $redux_builder_amp;
-		$fb_page_id = '';
-		$fb_page_id = $redux_builder_amp['fb-instant-page-id'];
+		$fb_page_id = isset($redux_builder_amp['fb-instant-page-id']) && $redux_builder_amp['fb-instant-page-id'];
 		// Page ID meta Tag
-		if(  isset($redux_builder_amp['fb-instant-page-id']) && $redux_builder_amp['fb-instant-page-id'] ) { ?>		
+		if( $redux_builder_amp['fb-instant-page-id'] ) { ?>		
 			<meta property="fb:pages" content="<?php echo esc_attr( $fb_page_id ); ?>" />
 		<?php }
 		$post = get_post();


### PR DESCRIPTION
Was getting the following error.

Notice: Undefined index: fb-instant-page-id in /wp-content/plugins/accelerated-mobile-pages/templates/features.php on line 4460