### PR TITLE
Upcoming Fix: Rank Math compatibility issue

### DIFF
--- a/templates/features.php
+++ b/templates/features.php
@@ -5988,7 +5988,7 @@ function ampforwp_generate_canonical(){
 		$canonical = $opts['aiosp_custom_link'];
 	}
 	elseif (defined( 'RANK_MATH_FILE' ) && 'rank_math' == ampforwp_get_setting('ampforwp-seo-selection') ) {
-		$canonical = rank_math()->head->canonical( false );
+		$canonical = \RankMath\Paper\Paper::get()->get_canonical();
 	}
 	return $canonical;
 }
@@ -6588,6 +6588,14 @@ if ( ! function_exists('ampforwp_get_weglot_url') ) {
 add_action('amp_post_template_head','ampforwp_rank_math');
 if ( ! function_exists('ampforwp_rank_math') ) {
 	function ampforwp_rank_math(){
+		// Early Bail if Rank Math is not selected in SEO Plugin Integration.
+		if ( 'rank_math' !== ampforwp_get_setting('ampforwp-seo-selection') ) {
+			return;
+		}
+
+		// Remove Canonical & Title Tag added by the Rank Math plugin.
+		remove_all_actions( 'rank_math/head', 20 );
+		remove_all_actions( 'rank_math/head', 1 );
 		do_action( 'rank_math/head' );
 	}
 }


### PR DESCRIPTION
In an upcoming update of the Rank Math SEO plugin, which will be released in the week of May 13th, 2019, this commit will help to maintain the compatibility between the two plugins since we changed the names of the classes in the Rank Math plugin.

Please merge this once we release an update. Will update in this pull request once we release an update.