### PR TITLE
Comment hooks

### DIFF
--- a/components/comments/comments.php
+++ b/components/comments/comments.php
@@ -7,6 +7,7 @@ function ampforwp_framework_get_comments(){
 	$display_comments_on = "";
 	$display_comments_on = ampforwp_get_comments_status();
 	if ( $display_comments_on ) {
+		do_action('ampforwp_before_comment_hook');
 		if ( $redux_builder_amp['ampforwp-facebook-comments-support']  ) { 
 		 	echo ampforwp_framework_get_facebook_comments(); 
 		}
@@ -22,7 +23,7 @@ function ampforwp_framework_get_comments(){
 		}
 	  
 		if ( isset($redux_builder_amp['wordpress-comments-support']) && true == $redux_builder_amp['wordpress-comments-support'] ) {
-			do_action('ampforwp_before_comment_hook'); ?>
+				?>
 				<div class="amp-comments">
 					<?php
 					// Gather comments for a specific page/post
@@ -130,8 +131,9 @@ function ampforwp_framework_get_comments(){
 						</div>	 
 				<?php } ?>
 				</div>
-			<?php do_action('ampforwp_after_comment_hook');
+			<?php
 		}
+		do_action('ampforwp_after_comment_hook');
 	} // end $display_comments_on
 }
 


### PR DESCRIPTION
We want to integrate [Coral](https://github.com/coralproject/talk) into this plugin and we already have a wordpress plugin that integrates Coral. So we were hoping to add amp support inside our wordpress plugin.

Question:
- Is it possible to move `ampforwp_before_comment_hook` and  `ampforwp_after_comment_hook` out of the `if` scope so that it is not tied to Wordpress comments?
- Or: is it possible to add another hook that is not tied to Wordpress comments?

Thanks!