### PR TITLE
 Undefined array key 3 fix in case of PHP <8.0

### DIFF
--- a/templates/features.php
+++ b/templates/features.php
@@ -9413,8 +9413,10 @@ function ampforwp_remove_homepage_breadcrumb($data){
 		if (isset($data["@graph"][2]["breadcrumb"])) {
 			unset($data["@graph"][2]["breadcrumb"]);
 		}
-		if ($data["@graph"][3]["@type"] == 'BreadcrumbList') {
-			unset($data["@graph"][3]);
+		if(array_key_exists(3, $data["@graph"]) {
+			if (!empty($data["@graph"][3]["@type"]) && $data["@graph"][3]["@type"] == 'BreadcrumbList') {
+				unset($data["@graph"][3]);
+			}
 		}
 	}
 	return $data;


### PR DESCRIPTION
Fix to PHP error `Trying to access array offset on value of type null` and `Undefined array key 3` in case of PHP v8+