### PR TITLE
1.1.5

### DIFF
--- a/accelerated-moblie-pages.php
+++ b/accelerated-moblie-pages.php
@@ -3,7 +3,7 @@
 Plugin Name: Accelerated Mobile Pages
 Plugin URI: https://wordpress.org/plugins/accelerated-mobile-pages/
 Description: AMP for WP - Accelerated Mobile Pages for WordPress
-Version: 1.1.4
+Version: 1.1.5
 Author: Ahmed Kaludi, Mohammed Kaludi
 Author URI: https://ampforwp.com/
 Donate link: https://www.paypal.me/Kaludi/25
@@ -20,7 +20,7 @@ define('AMPFORWP_PLUGIN_DIR_URI', plugin_dir_url(__FILE__));
 define('AMPFORWP_DISQUS_URL',plugin_dir_url(__FILE__).'includes/disqus.html');
 define('AMPFORWP_IMAGE_DIR',plugin_dir_url(__FILE__).'images');
 define('AMPFORWP_MAIN_PLUGIN_DIR', plugin_dir_path( __DIR__ ) );
-define('AMPFORWP_VERSION','1.1.4');
+define('AMPFORWP_VERSION','1.1.5');
 define('AMPFORWP_EXTENSION_DIR',plugin_dir_path(__FILE__).'includes/options/extensions');
 define('AMPFORWP_ANALYTICS_URL',plugin_dir_url(__FILE__).'includes/features/analytics');
 if(!defined('AMPFROWP_HOST_NAME')){

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= 1.1.5 (22 May 2025) =
+* Tested: Need to test with WordPress 6.8 #5686
+* Fixed : A fatal error occurs when we activate the AMP Page Builder. #5684
+* Feature : AMP is not showing .avif images #5670
+* Fixed: The attribute 'alt' may not appear in tag 'a'. #5682
+* Feature: Conflict issue with Penci widgets. #5683
+* Improvement: Need to improve Query of function ampforwp_get_post_percent() #5687
+
 = 1.1.4 (08 April 2025) =
 * Feature: Add setting button in Purge AMP CDN Cache #5671
 * Compatibility: Need to implement inMobi Choice #5678

--- a/includes/admin-script.js
+++ b/includes/admin-script.js
@@ -226,8 +226,7 @@ jQuery(function($) {
                  },
             success: function(response){
                 clearInterval(first_int);
-                response = response.replace("}0", "}");
-                var resp = JSON.parse(response);
+                var resp = response;
                 resp = parseInt(resp.response);
                 var id = setInterval(frame, 10);
                 var width = current_post;

--- a/includes/features/functions.php
+++ b/includes/features/functions.php
@@ -1325,38 +1325,78 @@ if( ! function_exists( 'ampforwp_additional_style_carousel_caption' ) ){
 if(!function_exists('ampforwp_sassy_share_icons')){
     function ampforwp_sassy_share_icons($ampforwp_the_content) {
         if(function_exists('heateor_sss_run')){
-            global $heateor_sss;global $post;
+            global $heateor_sss;
+            global $post;
             $share_counts = false;
             $sassy_options = $heateor_sss->options;
             $post_url = get_the_permalink($post);
+           
             if(isset($sassy_options['horizontal_counts'])){
                 $post_id = ampforwp_get_the_ID();
-                if ( $post_id == 'custom' ) {
-                    $share_counts =  get_option( 'heateor_sss_custom_url_shares' ) ;
-                } elseif ( $post_url == home_url() ) {
-                    $share_counts = get_option( 'heateor_sss_homepage_shares' );
-                } elseif ( $post_id > 0 ) {
-                    $share_counts = get_post_meta( $post_id, '_heateor_sss_shares_meta', true );
+
+                    if ( $post_id == 'custom' ) {
+                        $share_counts = get_option('heateor_sss_custom_url_shares');
+                    } elseif ( $post_url == home_url() ) {
+                        $share_counts = get_option('heateor_sss_homepage_shares');
+                    } elseif ( $post_id > 0 ) {
+                        $share_counts = get_post_meta($post_id, '_heateor_sss_shares_meta', true);
+                    }
                 }
                 $total_share = 0;
+                $_append = '';
+                $copy_link = '';
                 if(isset($sassy_options['horizontal_re_providers'])){
                     $share_icons = $sassy_options['horizontal_re_providers'];
                     foreach($share_icons as $i){
+                        if($i === 'Copy_Link') {
+                            // Manual copy field for AMP
+                            $copy_link = '<amp-iframe 
+                            width="auto"
+                            height="40"
+                            class="sss_copy_link" 
+                            sandbox="allow-scripts allow-modals" 
+                            layout="fixed-height" 
+                            frameborder="0"
+                            scrolling="no"
+                            style="overflow: hidden; border: none;width:40px;float:left;"
+                            src="' . esc_url( AMPFORWP_PLUGIN_DIR_URI . 'includes/sassy-social-share/copy-share.html?url=' . rawurlencode($post_url) ) . '">
+                            <div placeholder></div>
+                            <div fallback></div>
+                        </amp-iframe>';
+            
+                            continue;
+                        }
+
                         if(isset($share_counts[$i])){
                             $total_share += round($share_counts[$i]);
                         }
                     }
                 }
-                $_append = '<a class="heateor_sss_amp heateor-total-share-count">
-                                <span class="sss_share_count">'.intval($total_share).'</span> <span class="sss_share_lbl">Shares</span></a>';
+
+                if(isset($sassy_options['horizontal_counts'])){
+                $_append .= '<a class="heateor_sss_amp heateor-total-share-count">
+                                <span class="sss_share_count">'.intval($total_share).'</span> 
+                                <span class="sss_share_lbl">Shares</span>
+                             </a>';
+                }
+
                 preg_match_all('/<div class="heateorSssClear"><\/div><div class="heateor_sss_sharing_container (.*)">(.*)<div class="heateorSssClear"><\/div><\/div><div class="heateorSssClear"><\/div>/', $ampforwp_the_content, $matches);
                 
                 $_actual = $matches[0];
                 if(isset($matches[1][0])){
-                $_replace = '<div class="heateorSssClear"></div><div class="heateor_sss_sharing_container '.$matches[1][0].'"></amp-img></a>'.$_append.'</div><div class="heateorSssClear"></div><div class="heateorSssClear"></div>';
-                $ampforwp_the_content = str_replace($_actual, $_replace, $ampforwp_the_content);
+                    $_replace = '<div class="heateorSssClear"></div><div class="heateor_sss_sharing_container '.$matches[1][0].'">' . $matches[2][0] . $_append . '</div><div class="heateorSssClear"></div><div class="heateorSssClear"></div>';
+                    $ampforwp_the_content = str_replace($_actual, $_replace, $ampforwp_the_content);
                 }
-            }
+                
+                if($copy_link){
+                    $ampforwp_the_content = preg_replace_callback(
+                        '/(<div[^>]*class="[^"]*heateor_sss_sharing_ul[^"]*"[^>]*>)(.*?)(<\/div>)/is',
+                        function ($matches) use ($copy_link) {
+                            return $matches[1] . $matches[2] . $copy_link . $matches[3];
+                        },
+                        $ampforwp_the_content
+                    );
+                }
         }
         return $ampforwp_the_content;
     }

--- a/includes/options/admin-config.php
+++ b/includes/options/admin-config.php
@@ -3104,30 +3104,47 @@ Redux::setSection( $opt_name, array(
 );
 function ampforwp_get_post_percent() {
     global $wpdb;
-    if( get_transient( '_ampforwp_get_post_percent' ) ){
-        return get_transient( '_ampforwp_get_post_percent' );
+
+    // Check if the value is already stored in the options table
+    $cached_value = get_option('_ampforwp_get_post_percent');
+
+    if ($cached_value !== false) {
+        return round($cached_value);
     }
+
     // Total published posts
-    $total_post = (int) $wpdb->get_var( "SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_status = 'publish' AND post_type = 'post'" );
-    if ( $total_post === 0 ) {
+    $total_post = (int) $wpdb->get_var("
+        SELECT COUNT(ID)
+        FROM {$wpdb->posts}
+        WHERE post_status = 'publish'
+        AND post_type = 'post'
+    ");
+
+    if ($total_post === 0) {
         return 100;
     }
 
     // Count posts where meta_key 'ampforwp-amp-on-off' does NOT exist
-    $sql = "SELECT COUNT(p.ID)
+    $sql = "
+        SELECT COUNT(p.ID)
         FROM {$wpdb->posts} p
         LEFT JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id AND pm.meta_key = 'ampforwp-amp-on-off'
         WHERE pm.post_id IS NULL
         AND p.post_status = 'publish'
-        AND p.post_type = 'post'";
+        AND p.post_type = 'post'
+    ";
 
-    $non_amp_posts = (int) $wpdb->get_var( $sql );
+    $non_amp_posts = (int) $wpdb->get_var($sql);
+
     // Calculate percentage
     $post_percent = (($total_post - $non_amp_posts) / $total_post) * 100;
-    $post_percent = $post_percent;
-    set_transient( '_ampforwp_get_post_percent',  $post_percent);
+
+    // Store result in options table
+    update_option('_ampforwp_get_post_percent', $post_percent);
+
     return round($post_percent);
 }
+
 $post_percent = 0;
 $current_page = ampforwp_get_admin_current_page();
 $refresh_btn = "";

--- a/includes/sassy-social-share/copy-share.html
+++ b/includes/sassy-social-share/copy-share.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <style>
+    body { font-family: sans-serif; margin: 0; }
+    input { width: 100%; padding: 8px; font-size: 14px; }
+    a { text-decoration: none; color: #000; font-size: 35px;}
+  </style>
+</head>
+<body>
+  
+  <a href="javascript:void(0);" onclick="copyToClipboard()">&#128203;</a><br><br>
+  <input id="copyInput" value="" readonly/>
+
+  <script>
+    function getQueryParam(param) {
+        let urlParams = new URLSearchParams(window.location.search);
+        return urlParams.get(param);
+    }
+
+    function copyToClipboard() {
+      const input = document.getElementById("copyInput");
+      input.select();
+      input.setSelectionRange(0, 99999); // Mobile
+      document.execCommand("copy");
+      alert("Copied the URL: " + input.value);
+    }
+
+    document.getElementById("copyInput").value = getQueryParam("url") || window.location.href;
+  </script>
+</body>
+</html>

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: mohammed_kaludi, ahmedkaludi, ampforwp
 Tags: AMP, accelerated mobile pages, mobile, google amp, SEO
 Donate link: https://www.paypal.me/Kaludi/25
 Requires at least: 3.0
-Tested up to: 6.7
-Stable tag: 1.1.4
+Tested up to: 6.8
+Stable tag: 1.1.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -194,6 +194,14 @@ You can contact us from [here](https://ampforwp.com/contact/)
 11. Pingdom Speed Report for AMP
 
 == Changelog ==
+
+= 1.1.5 (22 May 2025) =
+* Tested: Need to test with WordPress 6.8 #5686
+* Fixed : A fatal error occurs when we activate the AMP Page Builder. #5684
+* Feature : AMP is not showing .avif images #5670
+* Fixed: The attribute 'alt' may not appear in tag 'a'. #5682
+* Feature: Conflict issue with Penci widgets. #5683
+* Improvement: Need to improve Query of function ampforwp_get_post_percent() #5687
 
 = 1.1.4 (08 April 2025) =
 * Feature: Add setting button in Purge AMP CDN Cache #5671

--- a/templates/features.php
+++ b/templates/features.php
@@ -8813,10 +8813,12 @@ function ampforwp_remove_unwanted_code($content){
 	if(empty($content)){
 		return $content;
 	}
-  //Remove label from anchor
+  
 	if(preg_match('/<a(.*?)\slabel\s(.*?)>/', $content)){
-		$content = preg_replace('/<a(.*?)\slabel\s(.*?)>/', '<a $1$2>', $content);
-	} 
+		$content = preg_replace_callback('/<a\b[^>]*>/i', function ($matches) {
+			return preg_replace('/\s*label\s*=\s*"[^"]*"/i', '', $matches[0]);
+		}, $content);
+	}
 	return $content;
 }
 add_filter( 'amp_post_template_css', 'ampforwp_add_penci_block_css' );

--- a/templates/features.php
+++ b/templates/features.php
@@ -997,7 +997,6 @@ function ampforwp_title_meta_save( $post_id ) {
          return ;
     }
 	$ampforwp_amp_status = '';
-	delete_transient('_ampforwp_get_post_percent');
     // Checks save status
     $is_autosave = wp_is_post_autosave( $post_id );
     $is_revision = wp_is_post_revision( $post_id );
@@ -9459,7 +9458,7 @@ function ampforwp_referesh_related_post() {
 	}
 
 	// Clear transient cache
-	delete_transient('_ampforwp_get_post_percent');
+	delete_option( '_ampforwp_get_post_percent' );
 
 	// Fetch up to 30 published posts without the meta key
 	$post_ids = $wpdb->get_col("

--- a/templates/features.php
+++ b/templates/features.php
@@ -7114,6 +7114,9 @@ function ampforwp_spotim_vuukle_styling(){
 			display: block;text-align: center;background: #1f87e5;color: #fff;border-radius: 4px;
 		} <?php 
 	}
+	?>
+	<?php
+
 }
 
 
@@ -8813,6 +8816,43 @@ function ampforwp_remove_unwanted_code($content){
   //Remove label from anchor
 	if(preg_match('/<a(.*?)\slabel\s(.*?)>/', $content)){
 		$content = preg_replace('/<a(.*?)\slabel\s(.*?)>/', '<a $1$2>', $content);
+	} 
+	return $content;
+}
+add_filter( 'amp_post_template_css', 'ampforwp_add_penci_block_css' );
+function ampforwp_add_penci_block_css() {
+	if(function_exists('penci_soledad_theme_setup')){
+?>
+.penci-biggrid-wrapper{margin-bottom:20px}.penci-clearfix{clear:both}.penci-homepage-title.pcalign-center{text-align:center}.penci-border-arrow{position:relative;line-height:1.3;margin-left:5px;margin-right:5px;margin-top:5px}.penci-homepage-title{margin-bottom:30px;text-align:center;clear:both;background:0 0}.penci-border-arrow .inner-arrow{border:1px solid #313131;background:#fff;position:relative;display:block;text-transform:uppercase;padding:8px 12px 7px;z-index:3;font-size:14px}.penci-biggrid-inner{overflow:hidden;display:block}.penci-bgstyle-1 .penci-dflex{margin-left:-10px;margin-right:-10px;width:calc(100% + 20px)}.penci-dflex{display:-webkit-flex;-webkit-flex-flow:row wrap;align-items:flex-start}.penci-bgstyle-1 .penci-dflex .penci-bgitem{padding:0 10px;margin-bottom:20px}.penci-bgmain{display:flex;flex-direction:column;position:relative}.pcbg-thumb,.penci-bgitin{position:relative;overflow:hidden}.pcbg-bgoverlay,.pcbg-bgoverlaytext,.pcbg-cbgoverlap,.pcbg-content{position:absolute;left:0;right:0;top:0;bottom:0;width:100%;height:100%;display:block}.pcbg-content-flex{display:flex;height:100%;width:100%;z-index:1;align-items:flex-end}.penci-biggrid-wrapper .pcbg-content-inner{z-index:5}.elementor *,.elementor :after,.elementor :before{box-sizing:border-box}.pcbg-content-inner{padding:20px;position:relative;z-index:1;display:block;width:100%}.pcbg-content-inner .cat>a.penci-cat-name,.pcbg-content-inner .cat>a.penci-cat-name:hover,.penci-bgrid-content-on .pcbg-content-inner .pcbg-title,.penci-bgrid-content-on .pcbg-content-inner .pcbg-title a,.penci-bgrid-content-on .pcbg-content-inner .pcbg-title a:hover,.penci-bgrid-content-on .pcbg-meta,.penci-bgrid-content-on .pcbg-meta span,.penci-bgrid-content-on .pcbg-meta span a{color:#fff}.penci-biggrid-data .pcbg-content-inner .pcbg-title,.penci-biggrid-data .pcbg-content-inner .pcbg-title a,.penci-biggrid-data .pcbg-content-inner .pcbg-title a:hover{letter-spacing:0;text-decoration:none;margin:0}.grid-post-box-meta a,.grid-post-box-meta span,.penci-biggrid-data .pcbg-content-inner .pcbg-title a{font-size:inherit}.post-entry .cat>a.penci-cat-name,.post-entry .grid-mixed .mixed-detail a,.post-entry .grid-post-box-meta a,.post-entry .header-standard .author-post span a,.post-entry .header-standard h2 a,.post-entry .item-related a,.post-entry .overlay-author a,.post-entry .overlay-header-box .overlay-title a,.post-entry .penci-featured-cat-seemore a,.post-entry .penci-grid li .item h2 a,.post-entry .penci-magazine-title a,.post-entry .penci-masonry .item-masonry h2 a,.post-entry .penci-post-box-meta .penci-box-meta a,.post-entry .penci-readmore-btn a{text-decoration:none}.cat>a.penci-cat-name:last-child{margin-right:0;padding:0}.cat>a.penci-cat-name:first-child{margin-left:0}.post-entry a:hover,.wpb_text_column a:hover{text-decoration:underline}.cat>a.penci-cat-name{font-size:13px;color:var(--pcaccent-cl);line-height:1.2;margin:0 15px 5px 0;padding-right:10px;display:inline-block;vertical-align:top;background:0 0;transition:.3s;-webkit-transition:.3s;-moz-transition:.3s;font-weight:400;position:relative;text-decoration:none}.penci-smalllist{display:block;width:100%;clear:both;--pcsl-hgap:20px;--pcsl-bgap:20px;--pcsl-between:20px;--pcsl-dwidth:15%;overflow:hidden}.pcsl-inner,.swiper.pcsl-inner{margin-left:calc(var(--pcsl-hgap) * -1 / 2);margin-right:calc(var(--pcsl-hgap) * -1 / 2);width:calc(100% + var(--pcsl-hgap));display:flex;flex-flow:row wrap;align-items:flex-start}.pcsl-inner .pcsl-item{padding:0 calc(var(--pcsl-hgap)/ 2);width:100%;margin-bottom:var(--pcsl-bgap)}.pcsl-col-3 .pcsl-item,.penci-grid-col-3 .penci-dflex .penci-bgitem{flex:0 0 33.33333%}.pcsl-inner .pcsl-iteminer{display:-webkit-flex;display:-ms-flexbox;-ms-flex-flow:row wrap;flex-flow:row wrap;align-items:flex-start}.pcsl-inner .pcsl-thumb{width:32%;order:2;transition:opacity .3s;position:relative}.pcsl-imgpos-left .pcsl-content{padding-right:0}.pcsl-inner .pcsl-content{width:68%;padding:0 var(--pcsl-between);order:3}.pcsl-inner .pcsl-content .pcsl-title{font-size:16px;color:var(--pcheading-cl);font-family:var(--pchead-font);font-weight:var(--pchead-wei);line-height:1.4;display:block}.pcsl-inner .pcsl-content .pcsl-title a{font-size:inherit;color:inherit;font-family:inherit;font-weight:inherit;text-decoration:none}.pcsl-inner .grid-post-box-meta,.post-entry .pcsl-inner .grid-post-box-meta{margin-top:8px;line-height:1.3;font-size:14px}.grid-post-box-meta span{color:#888}
+<?php
+	}
+}
+add_filter('ampforwp_the_content_last_filter','ampforwp_penci_widget_block_support',10);
+function ampforwp_penci_widget_block_support($content){
+	if(function_exists('penci_soledad_theme_setup')){
+		$pattern = '/<a\s+([^>]*?)data-bgset="([^"]+)"([^>]*?)>/i';
+		$replacement = function($matches) {
+			$a_tag_start = $matches[0]; 
+			$data_bgset = $matches[2];  
+			$width = '60';
+			$height = '40';
+			$amp_img_tag = '<amp-img src="' . esc_url( $data_bgset ) . '" width="' . esc_attr( $width ) . '" height="' . esc_attr( $height ) . '" layout="responsive"></amp-img>';
+
+			return preg_replace('/<a.*?>/', '<a>', $a_tag_start) . $amp_img_tag;
+		};
+		$content = preg_replace_callback($pattern, $replacement, $content); 
+		$pattern = '/<div\s+([^>]*?)data-bgset="([^"]+)"([^>]*?)>/i';
+		$replacement = function($matches) {
+			$a_tag_start = $matches[0]; 
+			$data_bgset = $matches[2];  
+			$width = '600';
+			$height = '400';
+			$amp_img_tag = '<amp-img src="' . esc_url( $data_bgset ) . '" width="' . esc_attr( $width ) . '" height="' . esc_attr( $height ) . '" layout="responsive"></amp-img>';
+			return preg_replace('/<a.*?>/', '<a>', $a_tag_start) . $amp_img_tag;
+		};
+		
+		$content = preg_replace_callback($pattern, $replacement, $content); 
+		return $content;
 	}
 	return $content;
 }

--- a/templates/features.php
+++ b/templates/features.php
@@ -10441,3 +10441,33 @@ function ampforwp_infinite_scroll_post_ajax(){
 	}
 	die;
 }
+function ampforwp_append_avif_to_img_srcset( $sources, $size_array, $image_src, $image_meta, $attachment_id ) {
+		$format = get_imagify_option( 'optimization_format' );
+		$display_nextgen = get_imagify_option( 'display_nextgen' );
+		
+		if($format==='avif' && $display_nextgen){
+			$upload_dir = wp_upload_dir();
+			$base_url = $upload_dir['baseurl'];
+			$file = get_attached_file( $attachment_id );
+			$filename = basename( $file );
+
+			// Get the base name without extension
+			$base_name = preg_replace('/\.[^.]+$/', '', $filename);
+			$upload_path = trailingslashit( dirname( wp_get_attachment_url( $attachment_id ) ) );
+			foreach ( $sources as $width => $data ) {
+				// Replace the .png or .jpg with .avif
+				$avif_url = preg_replace('/\.(png|jpg|jpeg)$/i', '.avif', $data['url']);
+				
+				// Add AVIF format version (same descriptor and value)
+				$sources[ $width . '-avif' ] = [
+					'url'        => $avif_url,
+					'descriptor' => 'w',
+					'value'      => $width,
+				];
+			}
+		}
+	return $sources;
+}
+if( function_exists('get_imagify_option')){
+	add_filter( 'wp_calculate_image_srcset', 'ampforwp_append_avif_to_img_srcset', 10, 5 );
+}


### PR DESCRIPTION
= 1.1.5 (22 May 2025) =
* Tested: Need to test with WordPress 6.8 #5686
* Fixed : A fatal error occurs when we activate the AMP Page Builder. #5684
* Feature : AMP is not showing .avif images #5670
* Fixed: The attribute 'alt' may not appear in tag 'a'. #5682
* Feature: Conflict issue with Penci widgets. #5683
* Improvement: Need to improve Query of function ampforwp_get_post_percent() #5687
