### PR TITLE
1.1.6

### DIFF
--- a/accelerated-moblie-pages.php
+++ b/accelerated-moblie-pages.php
@@ -3,7 +3,7 @@
 Plugin Name: Accelerated Mobile Pages
 Plugin URI: https://wordpress.org/plugins/accelerated-mobile-pages/
 Description: AMP for WP - Accelerated Mobile Pages for WordPress
-Version: 1.1.5
+Version: 1.1.6
 Author: Ahmed Kaludi, Mohammed Kaludi
 Author URI: https://ampforwp.com/
 Donate link: https://www.paypal.me/Kaludi/25
@@ -20,7 +20,7 @@ define('AMPFORWP_PLUGIN_DIR_URI', plugin_dir_url(__FILE__));
 define('AMPFORWP_DISQUS_URL',plugin_dir_url(__FILE__).'includes/disqus.html');
 define('AMPFORWP_IMAGE_DIR',plugin_dir_url(__FILE__).'images');
 define('AMPFORWP_MAIN_PLUGIN_DIR', plugin_dir_path( __DIR__ ) );
-define('AMPFORWP_VERSION','1.1.5');
+define('AMPFORWP_VERSION','1.1.6');
 define('AMPFORWP_EXTENSION_DIR',plugin_dir_path(__FILE__).'includes/options/extensions');
 define('AMPFORWP_ANALYTICS_URL',plugin_dir_url(__FILE__).'includes/features/analytics');
 if(!defined('AMPFROWP_HOST_NAME')){

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= 1.1.6 (28 July 2025) =
+* Tested: Tested upto WordPress 6.8.2
+* Fixed : Deprecated "Creation of dynamic property" #5688
+* Fixed : PHP 8.2 Deprecated Warnings in DOMDocument and Dynamic Property Creation in AMP . #5692
+* Fixed : Deprecated Warning: FILTER_SANITIZE_STRING used in framework.php line 2862 #5691
+* Fixed : Related post refresh not working #5693
+* Fixed : Fatal Error: Undefined Callback ampforwp_getty_image_compatibility in PHP 8.3 #56967
+
 = 1.1.5 (22 May 2025) =
 * Tested: Need to test with WordPress 6.8 #5686
 * Fixed : A fatal error occurs when we activate the AMP Page Builder. #5684

--- a/includes/options/redux-core/framework.php
+++ b/includes/options/redux-core/framework.php
@@ -2859,7 +2859,7 @@
                     //    unset($process);
                     //}
 /* phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized */
-                    $sanitized_data = filter_var(stripslashes( $_POST['data'] ), FILTER_SANITIZE_STRING, FILTER_FLAG_NO_ENCODE_QUOTES);
+                    $sanitized_data = htmlspecialchars(strip_tags(stripslashes($_POST['data'])), ENT_QUOTES, 'UTF-8');
 
                     // Old method of saving, in case we need to go back! - kp
                     //parse_str( $_POST['data'], $values );

--- a/includes/vendor/tool/Dom/Document.php
+++ b/includes/vendor/tool/Dom/Document.php
@@ -311,6 +311,7 @@ final class Document extends DOMDocument
      *
      * This is used to generate unique-per-prefix IDs.
      *
+     * 
      * @var int[]
      */
     private $indexCounter = [];
@@ -339,6 +340,10 @@ final class Document extends DOMDocument
      * @param string $version  Optional. The version number of the document as part of the XML declaration.
      * @param string $encoding Optional. The encoding of the document as part of the XML declaration.
      */
+    private $html = '';
+    private $head = '';
+    private $xpath = '';
+    private $body = '';
     public function __construct($version = '', $encoding = null)
     {
         $this->originalEncoding = (string)$encoding ?: Encoding::UNKNOWN;
@@ -2049,7 +2054,12 @@ final class Document extends DOMDocument
      */
     public function createElement($name, $value = null)
     {
-        $element = parent::createElement($name, $value);
+        $element = null;
+        if ($value !== null) {
+            $element = $dom->createElement('tagname', $value);
+        } else {
+            $element = $dom->createElement('tagname');
+        }
 
         if (!$element instanceof Element) {
             return false;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: AMP, accelerated mobile pages, mobile, google amp, SEO
 Donate link: https://www.paypal.me/Kaludi/25
 Requires at least: 3.0
 Tested up to: 6.8
-Stable tag: 1.1.5
+Stable tag: 1.1.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -195,6 +195,14 @@ You can contact us from [here](https://ampforwp.com/contact/)
 
 == Changelog ==
 
+= 1.1.6 (28 July 2025) =
+* Tested: Tested upto WordPress 6.8.2
+* Fixed : Deprecated "Creation of dynamic property" #5688
+* Fixed : PHP 8.2 Deprecated Warnings in DOMDocument and Dynamic Property Creation in AMP . #5692
+* Fixed : Deprecated Warning: FILTER_SANITIZE_STRING used in framework.php line 2862 #5691
+* Fixed : Related post refresh not working #5693
+* Fixed : Fatal Error: Undefined Callback ampforwp_getty_image_compatibility in PHP 8.3 #56967
+
 = 1.1.5 (22 May 2025) =
 * Tested: Need to test with WordPress 6.8 #5686
 * Fixed : A fatal error occurs when we activate the AMP Page Builder. #5684
@@ -347,15 +355,6 @@ You can contact us from [here](https://ampforwp.com/contact/)
 * Fixed: Validation error from recent AMP update version 1.0.88.1 #5518
 * Fixed: Fatal error in setting panel #5521
 
-= 1.0.89 (14th September 2023) =
-* New: Piwik Pro Analytics #5510
-* New: compatibility with EmbedPress #5486
-* Fixed: Conflict WP-Bakery page builder with AMP #5417
-* Fixed: Warning in error log #5504
-* Fixed: Uncaught ValueError: DOMDocument::loadHTML(): Argument #1 ($source) must not be empty #5512
-* Fixed: Header Font Size Offset Changing After Update 1.0.86 #5496
-* Fixed: Various deprecated warning in PHP 8.2+ related to dynamic property creation #5515
-* Fixed: Added post data variables in GTM advanced code #5498
 
 
 Full changelog available [ at changelog.txt](https://plugins.svn.wordpress.org/accelerated-mobile-pages/trunk/changelog.txt)

--- a/templates/features.php
+++ b/templates/features.php
@@ -10004,6 +10004,7 @@ function ampforwp_get_gitty_image_embed( $html, $url, $attr, $post_ID ) {
 	return $html; 
 }
 
+if( ! function_exists('ampforwp_getty_image_compatibility') ){
 function ampforwp_getty_image_compatibility($content){
 	global $getty_img_content;
 	if(is_array($getty_img_content)){
@@ -10045,6 +10046,7 @@ function ampforwp_getty_image_compatibility($content){
 		}
 		return $content;
 	}
+}
 
 if(function_exists('vp_pfui_admin_init') && function_exists('penci_setup')){
 	add_action('ampforwp_before_post_content','ampforwp_pennews_audio_embed');

--- a/templates/features.php
+++ b/templates/features.php
@@ -9448,43 +9448,84 @@ function ampforwp_themify_compatibility($content){
 
 add_action( 'wp_ajax_ampforwp_referesh_related_post', 'ampforwp_referesh_related_post' );
 function ampforwp_referesh_related_post() {
-	global $wpdb;
+    global $wpdb;
 
-	if (
+   if (
 		! isset($_POST['verify_nonce']) ||
 		! wp_verify_nonce($_POST['verify_nonce'], 'ampforwp_refresh_related_poost')
 	) {
 		wp_send_json(array('status' => 403, 'message' => esc_html__('User request is not allowed', 'accelerated-mobile-pages')));
 	}
 
-	// Clear transient cache
-	delete_option( '_ampforwp_get_post_percent' );
 
-	// Fetch up to 30 published posts without the meta key
-	$post_ids = $wpdb->get_col("
-		SELECT p.ID
-		FROM {$wpdb->posts} p
-		LEFT JOIN {$wpdb->postmeta} pm ON p.ID = pm.post_id AND pm.meta_key = 'ampforwp-amp-on-off'
-		WHERE pm.post_id IS NULL
-		AND p.post_status = 'publish'
-		AND p.post_type = 'post'
-		ORDER BY p.ID ASC
-		LIMIT 30
-	");
+    // Clear cache to avoid interference
+    wp_cache_flush();
 
-	// Bulk insert default meta value
-	if (!empty($post_ids)) {
-		$values = array();
-		foreach ($post_ids as $post_id) {
-			$values[] = $wpdb->prepare("(%d, %s, %s)", $post_id, 'ampforwp-amp-on-off', 'default');
-		}
-		$values_sql = implode(',', $values);
-		$wpdb->query("INSERT INTO {$wpdb->postmeta} (post_id, meta_key, meta_value) VALUES $values_sql");
-	}
+    // Optimized query
+    $post_ids = $wpdb->get_col("
+        SELECT p.ID
+        FROM {$wpdb->posts} p
+        WHERE p.post_status = 'publish'
+        AND p.post_type = 'post'
+        AND NOT EXISTS (
+            SELECT 1
+            FROM {$wpdb->postmeta} pm
+            WHERE pm.post_id = p.ID
+            AND pm.meta_key = 'ampforwp-amp-on-off'
+        )
+        ORDER BY p.ID ASC
+        LIMIT 30
+    ");
 
-	// Return updated percent
-	$data['response'] = ampforwp_get_post_percent();
-	wp_send_json($data);
+    error_log("Post IDs retrieved: " . print_r($post_ids, true));
+
+    $inserted_count = 0;
+    foreach ($post_ids as $post_id) {
+        if (!is_numeric($post_id) || $post_id <= 0) {
+            error_log("Invalid post ID: $post_id");
+            continue;
+        }
+
+        $post_id = (int) $post_id;
+        // Check if meta exists to avoid redundant query
+        if (metadata_exists('post', $post_id, 'ampforwp-amp-on-off')) {
+            error_log("Meta already exists for post ID $post_id");
+            continue;
+        }
+
+        if (add_post_meta($post_id, 'ampforwp-amp-on-off', 'default', true)) {
+            error_log("Successfully added meta for post ID $post_id.");
+            $inserted_count++;
+            wp_cache_delete($post_id, 'post_meta');
+        } else {
+            error_log("Failed to add meta for post ID $post_id: " . $wpdb->last_error);
+        }
+    }
+
+    // Invalidate percentage cache if used
+    if ($inserted_count > 0) {
+        delete_option('_ampforwp_get_post_percent');
+        error_log("Total posts inserted: $inserted_count");
+    } else {
+        error_log("No posts inserted.");
+    }
+
+    // Return updated percent
+    $response = null;
+    try {
+        $response = ampforwp_get_post_percent();
+    } catch (Exception $e) {
+        error_log("Error in ampforwp_get_post_percent: " . $e->getMessage());
+        $response = 'Error calculating percentage';
+    }
+
+    $data = array(
+        'status' => 200,
+        'inserted_count' => $inserted_count,
+        'response' => $response,
+        'post_ids' => $post_ids, // Include for debugging
+    );
+    wp_send_json($data);
 }
 
 


### PR DESCRIPTION
AMP for WP 1.1.6 released

* Tested: Tested upto WordPress 6.8.2
* Fixed : Deprecated "Creation of dynamic property" #5688
* Fixed : PHP 8.2 Deprecated Warnings in DOMDocument and Dynamic Property Creation in AMP . #5692
* Fixed : Deprecated Warning: FILTER_SANITIZE_STRING used in framework.php line 2862 #5691
* Fixed : Related post refresh not working #5693
* Fixed : Fatal Error: Undefined Callback ampforwp_getty_image_compatibility in PHP 8.3 #56967